### PR TITLE
Update qkneighborsclassifier.py

### DIFF
--- a/qiskit_quantum_knn/qknn/qkneighborsclassifier.py
+++ b/qiskit_quantum_knn/qknn/qkneighborsclassifier.py
@@ -363,7 +363,9 @@ class QKNeighborsClassifier(QuantumAlgorithm):
                         (-1) ** int(control_state) * \
                         (counts[state_str]) / control_counts[control_state] * \
                         (1 - exp_fidelity ** 2)
-            index_state = int(comp_state, 2)
+            index_state = int(
+                comp_state[::-1], 2
+            )  # Qiskit uses somewhat unconvential reverse ordering of tensor product states
             fidelity *= 2 ** num_qubits / 2
             fidelity += exp_fidelity
             fidelities[index_state] = fidelity
@@ -438,7 +440,9 @@ class QKNeighborsClassifier(QuantumAlgorithm):
                     contrast += \
                         (-1) ** int(control_state) * \
                         (counts[state_str]) / control_counts[control_state]
-            index_state = int(comp_state, 2)
+            index_state = int(
+                comp_state[::-1], 2
+            )  # Qiskit uses somewhat unconvential reverse ordering of tensor product states
             contrasts[index_state] = contrast
 
         return contrasts


### PR DESCRIPTION
Related to: https://github.com/GroenteLepel/qiskit-quantum-knn/issues/11

When mapping back the computational state to an index, we need to flip the order, since Qiskit uses a somewhat unconvential reverse ordering of tensor product states.

From their [documentation](https://qiskit.org/documentation/tutorials/circuits/1_getting_started_with_qiskit.html#:~:text=Qiskit%20uses%20an%20ordering%20in,Q1%E2%8A%97Q0.):

```
When representing the state of a multi-qubit system, the tensor order used in Qiskit is different than that used in most physics textbooks. Suppose there are 𝑛 qubits, and qubit 𝑗 is labeled as 𝑄𝑗. Qiskit uses an ordering in which the 𝑛th qubit is on the left side of the tensor product, so that the basis vectors are labeled as 𝑄𝑛−1⊗⋯⊗𝑄1⊗𝑄0.

For example, if qubit zero is in state 0, qubit 1 is in state 0, and qubit 2 is in state 1, Qiskit would represent this state as |100⟩, whereas many physics textbooks would represent it as |001⟩.
```